### PR TITLE
Rename \doi to \assigneddoi

### DIFF
--- a/authors/sigplanconf-template.tex
+++ b/authors/sigplanconf-template.tex
@@ -41,7 +41,7 @@
 \conferenceinfo{CONF 'yy}{Month d--d, 20yy, City, ST, Country} 
 \copyrightyear{20yy} 
 \copyrightdata{978-1-nnnn-nnnn-n/yy/mm} 
-\doi{nnnnnnn.nnnnnnn}
+\assigneddoi{nnnnnnn.nnnnnnn}
 
 % Uncomment one of the following two, if you are not going for the 
 % traditional copyright transfer agreement.

--- a/authors/sigplanconf.cls
+++ b/authors/sigplanconf.cls
@@ -853,7 +853,7 @@
 
 \let \crdata = \copyrightdata
 
-\newcommand{\doi}[1]{%
+\newcommand{\assigneddoi}[1]{%
   \gdef \@doi {#1}}
 
 \newcommand{\proceedings}[1]{%


### PR DESCRIPTION
Fixes #5 .

I'm not sure that this is the best solution, but this is way better than the broken state it is in right now.