### PR TITLE
Added support for optional hyperref package

### DIFF
--- a/authors/sigplanconf.cls
+++ b/authors/sigplanconf.cls
@@ -1074,11 +1074,13 @@
 %                       Title Page
 %                       ----- ----
 
-
 \@setflag \@addauthorsdone = \@false
+\@setflag \@hyperref = \@false
+\AtBeginDocument{\@ifpackageloaded{hyperref}{\@setflag \@hyperref = \@true}}
 
 \def \@titletext {\@latex@error{No title was provided}{}}
 \def \@subtitletext {}
+\def \@authors {}
 
 \newcount{\@authorcount}
 
@@ -1094,6 +1096,11 @@
   \gdef \@subtitletext {#1}}
 
 \newcommand{\authorinfo}[3]{%           {names}{affiliation}{email/URL}
+  \ifcase\@authorcount%
+    \edef\@authors{#1}%
+  \else%
+    \edef\@authors{{\@authors} and #1}%
+  \fi%
   \global\@increment \@authorcount
   \@withname\gdef {\@authorname\romannumeral\@authorcount}{#1}%
   \@withname\gdef {\@authoraffil\romannumeral\@authorcount}{#2}%
@@ -1107,6 +1114,14 @@
   \gdef \@titlebanner {#1}}
 
 \renewcommand{\maketitle}{%
+  \if\@hyperref
+    \ifx\@empty\@subtitletext%
+      \hypersetup{pdftitle=\@titletext}
+    \else
+      \hypersetup{pdftitle=\@titletext: \@subtitletext}
+    \fi
+    \hypersetup{pdfauthor=\@authors}
+  \fi
   \pagestyle{plain}%
   \if \@onecolumn
     {\hsize = \standardtextwidth

--- a/authors/sigplanconf.cls
+++ b/authors/sigplanconf.cls
@@ -1076,7 +1076,7 @@
 
 \@setflag \@addauthorsdone = \@false
 \@setflag \@hyperref = \@false
-\AtBeginDocument{\@ifpackageloaded{hyperref}{\@setflag \@hyperref = \@true}}
+\AtBeginDocument{\@ifpackageloaded{hyperref}{\@setflag \@hyperref = \@true}{}}
 
 \def \@titletext {\@latex@error{No title was provided}{}}
 \def \@subtitletext {}


### PR DESCRIPTION
This pull request uses the `hyperref` LaTeX package to produce PDFs with correct `Title` and `Author` annotations.

There are two variants of this depending on whether you want to make `hyperref` a required or optional dependency of `sigplanconf.cls`.  In this branch, `hyperref-optional`, it is optional.  In the [`hyperref-required`](https://github.com/adamsmd/online/tree/hyperref-required) branch, it is required.  Only one of these two branches should be merged.

An example document showing this in action is attached as [hyperpdf.zip](https://github.com/SIGPLAN/online/files/106200/hyperpdf.zip).

(It would be nice to do the same for `Keywords`, but since the `\keywords` macro takes no arguments, I don't see a way to get a copy of the keywords to then annotate the PDF with.)
