### PR TITLE
Use lmtt instead of cmtt so bold text shows propery

### DIFF
--- a/authors/sigplanconf.cls
+++ b/authors/sigplanconf.cls
@@ -441,6 +441,7 @@
 %                       Fonts
 %                       -----
 
+\renewcommand{\ttdefault}{lmtt} % cmtt doesn't have bold so use lmtt
 
 \if \@times
   \renewcommand{\rmdefault}{ptm}%


### PR DESCRIPTION
Currently, `sigplanconf` uses `cmtt` for the `\ttfamily` of fonts. However, `cmtt` does not have fonts
for `\bfseries`. LaTeX substitutes the `\mdseries` in that case, which effectively makes text that should be bold not be bold.

LaTeX issues a warning about this, but it is easy to miss.

This is fixed by using `lmtt` instead of `cmtt` for the `\ttfamily`.

The attached LaTeX document ([cmtt.zip](https://github.com/SIGPLAN/online/files/107061/cmtt.zip)) demonstrates this.

Note that there is still a problem with `\scshape` (i.e. small caps).
